### PR TITLE
Update libc dependency to v0.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "pretty-bytes"
 version = "0.1.0"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,6 +13,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.10"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
+"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-getopts = "0.2.4"
-libc = "0.1"
+getopts = "0.2"
+libc = "0.2"


### PR DESCRIPTION
`libc` has already published v0.2.

Also drop the patch number for getopts.

ref https://github.com/uutils/coreutils/issues/999

cc @raphlinus