### PR TITLE
STDIN_FILENO is no longer exported for Windows in libc v0.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "pretty-bytes"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,11 @@ use ::converter;
 use std::io;
 use std::env;
 use getopts::Options;
-use libc::{isatty, STDIN_FILENO};
+use libc::isatty;
+#[cfg(unix)]
+use libc::STDIN_FILENO;
+#[cfg(windows)]
+const STDIN_FILENO: i32 = 0;
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!(


### PR DESCRIPTION
My fault. This fixes the [compilation failure](https://ci.appveyor.com/project/Arcterus/coreutils/build/1.0.521/job/14c09s0ribc41gkw) on Windows.

Ref:

http://stackoverflow.com/questions/13531677/stdin-fileno-undeclared-in-windows
http://pubs.opengroup.org/onlinepubs/7908799/xsh/unistd.h.html
http://rust-lang.github.io/libc/x86_64-pc-windows-msvc/libc/

Maybe it's helpful to set up a Windows buildbot using appveyor?