### PR TITLE
Use atty crate instead of libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,18 @@
 name = "pretty-bytes"
 version = "0.2.0"
 dependencies = [
+ "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12,10 +22,33 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
+"checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ readme = "README.md"
 
 [dependencies]
 getopts = "0.2"
-libc = "0.2"
+atty = "0.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,11 +3,7 @@ use ::converter;
 use std::io;
 use std::env;
 use getopts::Options;
-use libc::isatty;
-#[cfg(unix)]
-use libc::STDIN_FILENO;
-#[cfg(windows)]
-const STDIN_FILENO: i32 = 0;
+use atty::{self, Stream};
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!(
@@ -21,13 +17,8 @@ fn print_version() {
     println!("{}", env!("CARGO_PKG_VERSION"));
 }
 
-fn stdin_isatty() -> bool {
-    let istty = unsafe { isatty(STDIN_FILENO as i32) };
-    istty == 1
-}
-
 pub fn run(args: env::Args) -> () {
-    let num: f64 = if stdin_isatty() {
+    let num: f64 = if atty::is(Stream::Stdin) {
         let args: Vec<String> = args.collect();
         let ref program = args[0];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate getopts;
-extern crate libc;
+extern crate atty;
 
 pub mod cli;
 pub mod converter;


### PR DESCRIPTION
This avoids direct use of anything platform specific, and is a reduction in code (not counting the generated Cargo.lock).